### PR TITLE
[AE-313] Add set_twitter_byo / clear_twitter_byo for X BYO header injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build/
 # Environment
 venv/
 env/
-.venv/
+.venv*/
 
 # IDE and OS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] 2026-04-28
+
+- Added `set_twitter_byo(api_key, api_secret)` and `clear_twitter_byo()` for X/Twitter Bring-Your-Own-Keys support. When set, every outbound request includes `X-Twitter-OAuth1-Api-Key` and `X-Twitter-OAuth1-Api-Secret` headers — required for posting to X after the March 31, 2026 BYO enforcement date.
+
 ## [1.2.5] 2026-01-20
 - Updates missing endpoint base url reference from app.ayrshare.com to api.ayrshare.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [1.3.0] 2026-04-28
 
-- Added `set_twitter_byo(api_key, api_secret)` and `clear_twitter_byo()` for X/Twitter Bring-Your-Own-Keys support. When set, every outbound request includes `X-Twitter-OAuth1-Api-Key` and `X-Twitter-OAuth1-Api-Secret` headers — required for posting to X after the March 31, 2026 BYO enforcement date.
+- Added `set_twitter_byo(api_key, api_secret)` and `clear_twitter_byo()` for X/Twitter Bring-Your-Own-Keys support. When set, every outbound request includes `X-Twitter-OAuth1-Api-Key` and `X-Twitter-OAuth1-Api-Secret` headers — required for X/Twitter operations now that Ayrshare's BYO requirement is enforced (as of March 31, 2026).
+- README: removed duplicated paragraphs, fixed typos (e.g. capabilities, Google Business Profile), corrected links (update post, generate alt text), tightened intro copy.
 
 ## [1.2.5] 2026-01-20
 - Updates missing endpoint base url reference from app.ayrshare.com to api.ayrshare.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.3.0] 2026-04-28
+## [1.3.0] 2026-05-08
 
 - Added `set_twitter_byo(api_key, api_secret)` and `clear_twitter_byo()` for X/Twitter Bring-Your-Own-Keys support. When set, every outbound request includes `X-Twitter-OAuth1-Api-Key` and `X-Twitter-OAuth1-Api-Secret` headers — required for X/Twitter operations now that Ayrshare's BYO requirement is enforced (as of March 31, 2026).
 - README: removed duplicated paragraphs, fixed typos (e.g. capabilities, Google Business Profile), corrected links (update post, generate alt text), tightened intro copy.

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Multi-tenant rotation:
 
 ``` python
 social.set_twitter_byo(tenant_a_key, tenant_a_secret)
-social.post({ ... })
+social.post({"post": "Hello from BYO", "platforms": ["twitter"]})
 
 social.clear_twitter_byo().set_twitter_byo(tenant_b_key, tenant_b_secret)
-social.post({ ... })
+social.post({"post": "Hello from BYO", "platforms": ["twitter"]})
 ```
 
 See the [X/Twitter BYO setup guide](https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys) for instructions on obtaining your X consumer key and secret.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ from ayrshare import SocialPost
 social = SocialPost('DJED-DKEP-SJWK-WJKS') # get an API Key at ayrshare.com
 ```
 
+### X/Twitter Bring-Your-Own-Keys (BYO)
+
+Starting **March 31, 2026**, X/Twitter operations through Ayrshare require your own X Developer App credentials. Set them once after construction and every subsequent SDK call will include the required `X-Twitter-OAuth1-*` headers.
+
+``` python
+from ayrshare import SocialPost
+
+social = SocialPost(API_KEY)
+social.set_twitter_byo(MY_X_API_KEY, MY_X_API_SECRET)
+
+social.post({"post": "Hello from BYO", "platforms": ["twitter"]})
+```
+
+Multi-tenant rotation:
+
+``` python
+social.set_twitter_byo(tenant_a_key, tenant_a_secret)
+social.post({ ... })
+
+social.clear_twitter_byo().set_twitter_byo(tenant_b_key, tenant_b_secret)
+social.post({ ... })
+```
+
+See the [X/Twitter BYO setup guide](https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys) for instructions on obtaining your X consumer key and secret.
+
 ### History, Post, Delete Example
 
 This simple example shows how to post, get history, and delete the post. This example assumes you have a free API key from [Ayrshare](https://www.ayrshare.com) and have enabled X/Twitter, Facebook, and LinkedIn. Note, Instagram, Telegram, YouTube, TikTok, and Reddit also available.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,16 @@
 
 ![Ayrshare logo](https://www.ayrshare.com/wp-content/uploads/2020/08/ayr-logo-2156-reduced.png)
 
-The Social Media API is a Python wrapper SDK for [Ayrshare's APIs](https://www.ayrshare.com). While most of the capabliites are supported, the Python wrapper SDK is not as feature complete as the [Ayrshare's APIs](https://www.ayrshare.com/docs/introduction).
-The Social Media API is a Python wrapper SDK for [Ayrshare's APIs](https://www.ayrshare.com). While most of the capabliites are supported, the Python wrapper SDK is not as feature complete as the [Ayrshare's APIs](https://www.ayrshare.com/docs/introduction).
+The Social Media API is a Python wrapper SDK for [Ayrshare's APIs](https://www.ayrshare.com). While most capabilities are supported, this Python wrapper is not as feature complete as the [REST API](https://www.ayrshare.com/docs/introduction).
 
 ## What is Ayrshare?
 
-Ayrshare is a powerful set of APIs that enable you to send social media posts, get analytics, manage comments, do DMs, and more to *X/Twitter*, *Instagram*, *Facebook*, *LinkedIn*, *YouTube*, *Google Busienss Profile*, *Pinterest*, *TikTok*, *Reddit*, and *Telegram* on behalf of your users or clients.
+Ayrshare is a powerful set of APIs that enable you to send social media posts, get analytics, manage comments, DMs, and more to *X/Twitter*, *Instagram*, *Facebook*, *LinkedIn*, *YouTube*, *Google Business Profile*, *Pinterest*, *TikTok*, *Reddit*, and *Telegram* on behalf of your users or clients.
 
-The Ayrshare Social API handles all the setup and maintenance for the social media networks. One API to rule them all (yeah, went there). See the full list of [full list of features](https://www.ayrshare.com/docs/apis/overview).
-The Ayrshare Social API handles all the setup and maintenance for the social media networks. One API to rule them all (yeah, went there). See the full list of [full list of features](https://www.ayrshare.com/docs/apis/overview).
+The Ayrshare Social API handles setup and maintenance for the social networks—one integration for many platforms. See the [full list of features](https://www.ayrshare.com/docs/apis/overview).
 
 Get started with a [free plan](https://www.ayrshare.com/pricing), or if you have a platform or manage multiple users check out the [Business Plan](https://www.ayrshare.com/business-plan-for-multiple-users/).
 
-For more information on setup, see our installation [video](https://youtu.be/G8M6DZdtcMc) or our [Quick Start Guide](https://www.ayrshare.com/docs/quickstart).
 For more information on setup, see our installation [video](https://youtu.be/G8M6DZdtcMc) or our [Quick Start Guide](https://www.ayrshare.com/docs/quickstart).
 
 ## Installation
@@ -29,13 +26,15 @@ To verify your install (no API key required): `python smoke_test.py`
 
    ![alt Social Accounts Setup](https://www.ayrshare.com/wp-content/uploads/Ayrshare-login.png)
 
-**2.** Enable your social media accounts such as C/Twitter, Facebook, LinkedIn, Reddit, Instagram, Google Business Profile, Telegram, TikTok, or YouTube in the Ayrshare dashboard.
+**2.** Enable your social media accounts such as X/Twitter, Facebook, LinkedIn, Reddit, Instagram, Google Business Profile, Telegram, TikTok, or YouTube in the Ayrshare dashboard.
 
    ![alt Social Accounts Setup](https://www.ayrshare.com/wp-content/uploads/Ayrshare-social-linking.png)
   
 **3.** Copy your API Key from the Ayrshare dashboard. Used for authentication.
 
    ![alt API Key](https://www.ayrshare.com/wp-content/uploads/Ayrshare-API-key.png)
+
+**X/Twitter:** Posting via this SDK requires your own X Developer App consumer key and secret (Bring-Your-Own-Keys / BYOK). Use `social.set_twitter_byo(api_key, api_secret)` — see **[X/Twitter Bring-Your-Own-Keys (BYO)](#xtwitter-bring-your-own-keys-byo)** below and the [X/Twitter BYO setup guide](https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys).
 
 ## Getting Started
 
@@ -50,7 +49,9 @@ social = SocialPost('DJED-DKEP-SJWK-WJKS') # get an API Key at ayrshare.com
 
 ### X/Twitter Bring-Your-Own-Keys (BYO)
 
-Starting **March 31, 2026**, X/Twitter operations through Ayrshare require your own X Developer App credentials. Set them once after construction and every subsequent SDK call will include the required `X-Twitter-OAuth1-*` headers.
+*(Same requirement is often called **BYOK** — bring your own key.)*
+
+As of **March 31, 2026**, posting and other X/Twitter actions through Ayrshare **require** your own X Developer App consumer key and secret in the outbound API request — Ayrshare enforces this on every X-bound call. Call `social.set_twitter_byo(api_key, api_secret)` once on the instance; afterwards **every request** issued by this `SocialPost` client includes the headers `X-Twitter-OAuth1-Api-Key` and `X-Twitter-OAuth1-Api-Secret` per the [official BYO docs](https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys).
 
 ``` python
 from ayrshare import SocialPost
@@ -71,25 +72,26 @@ social.clear_twitter_byo().set_twitter_byo(tenant_b_key, tenant_b_secret)
 social.post({"post": "Hello from BYO", "platforms": ["twitter"]})
 ```
 
-See the [X/Twitter BYO setup guide](https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys) for instructions on obtaining your X consumer key and secret.
-
 ### History, Post, Delete Example
 
-This simple example shows how to post, get history, and delete the post. This example assumes you have a free API key from [Ayrshare](https://www.ayrshare.com) and have enabled X/Twitter, Facebook, and LinkedIn. Note, Instagram, Telegram, YouTube, TikTok, and Reddit also available.
+This example posts to Twitter, Facebook, and LinkedIn. You need a free [Ayrshare](https://www.ayrshare.com) API key and those networks enabled in the dashboard. **Twitter requires BYO** — use your X app’s consumer key and secret (same as in the **X/Twitter BYO** section above).
 
 ``` python
 from ayrshare import SocialPost
 social = SocialPost('8jKj782Aw8910dCN') # get an API Key at ayrshare.com
 
-# Post to Platforms Twitter, Facebook, and LinkedIn
+# Required for X/Twitter in `platforms` (BYO / BYOK)
+social.set_twitter_byo('YOUR_X_CONSUMER_KEY', 'YOUR_X_CONSUMER_SECRET')
+
 postResult = social.post({'post': 'Nice Posting 2', 'platforms': ['twitter', 'facebook', 'linkedin']})
 print(postResult)
 
-# Delete
+# /post returns the Ayrshare post id at the top level as `id`. Per-platform
+# IDs live under `postIds[]`, but delete/getPost/analytics all expect the
+# Ayrshare-level id. See https://www.ayrshare.com/docs/apis/overview#social-post-id
 deleteResult = social.delete({'id': postResult['id']})
 print(deleteResult)
 
-# History
 print(social.history())
 ```
 
@@ -121,9 +123,10 @@ postResponse = social.post({
 })
 ```
 
+If `"twitter"` is included in `platforms`, call `social.set_twitter_byo(x_consumer_key, x_consumer_secret)` before `post` (and any other X-related calls you make with the same client). See [X/Twitter Bring-Your-Own-Keys (BYO)](#xtwitter-bring-your-own-keys-byo).
+
 ### Delete
 
-Delete a post with a given post ID, obtained from the "post" response. Returns a promise with the delete status. Also, can bulk delete multiple IDs at once using the "bulk" key. See the [delete endpoint](https://www.ayrshare.com/docs/apis/post/delete-post) for more details.
 Delete a post with a given post ID, obtained from the "post" response. Returns a promise with the delete status. Also, can bulk delete multiple IDs at once using the "bulk" key. See the [delete endpoint](https://www.ayrshare.com/docs/apis/post/delete-post) for more details.
 
 ``` python
@@ -137,7 +140,6 @@ deleteResponse = social.delete({
 ### Get Post
 
 Get a post with a given post ID. Returns a promise that resolves to a post object. See the [get post endpoint](https://www.ayrshare.com/docs/apis/post/get-post) for more details.
-Get a post with a given post ID. Returns a promise that resolves to a post object. See the [get post endpoint](https://www.ayrshare.com/docs/apis/post/get-post) for more details.
 
 ``` python
 getResponse = social.getPost({
@@ -149,7 +151,6 @@ getResponse = social.getPost({
 ### Retry Post
 
 Retry a failed post with a given post ID. Returns a promise that resolves to an object with the post status. See the [retry post endpoint](https://www.ayrshare.com/docs/apis/post/retry-post) for more details.
-Retry a failed post with a given post ID. Returns a promise that resolves to an object with the post status. See the [retry post endpoint](https://www.ayrshare.com/docs/apis/post/retry-post) for more details.
 
 ``` python
 retryResponse = social.retryPost({
@@ -160,7 +161,7 @@ retryResponse = social.retryPost({
 
 ### Update Post
 
-Update a post with a given post ID. Returns a promise that resolves to an object with status and update info. See the [update post endpoint](https://www.ayrshare.com/docs/apis/post/retry-post) for more details.
+Update a post with a given post ID. Returns a promise that resolves to an object with status and update info. See the [update post endpoint](https://www.ayrshare.com/docs/apis/post/update-post) for more details.
 
 ``` python
 updateResponse = social.updatePost({
@@ -208,7 +209,6 @@ uploadResponse = social.upload({
 ### Get Media
 
 Get all media URLS. Returns a promise that resolves to an array of URL objects. See the [media endpoint](https://www.ayrshare.com/docs/apis/media/get-media-in-gallery) for more details.
-Get all media URLS. Returns a promise that resolves to an array of URL objects. See the [media endpoint](https://www.ayrshare.com/docs/apis/media/get-media-in-gallery) for more details.
 
 ``` python
 mediaResponse = social.media()
@@ -216,7 +216,6 @@ mediaResponse = social.media()
 
 ### Verify Media Exists
 
-Verify that the media file exists when uploaded. See the [media verify exists endpoint](https://www.ayrshare.com/docs/apis/media/verify-media-url) for more details.
 Verify that the media file exists when uploaded. See the [media verify exists endpoint](https://www.ayrshare.com/docs/apis/media/verify-media-url) for more details.
 
 ``` python
@@ -228,7 +227,6 @@ verifyResponse = social.verifyMediaExists({
 
 ### Resize Image
 
-Get image resized according to social network requirements. See the [resize image endpoint](https://www.ayrshare.com/docs/apis/media/resize) for more details.
 Get image resized according to social network requirements. See the [resize image endpoint](https://www.ayrshare.com/docs/apis/media/resize) for more details.
 
 ``` python
@@ -295,7 +293,7 @@ Add a new RSS or Substack feed to auto post all new articles. Returns a promise 
 
 ``` python
 feedResponse = social.addFeed({
-  # Required: URL to shorten
+  # Required: RSS or Substack feed URL
   'url': 'https://theRSSFeed',
 
   # Optional: Value: "rss" or "substack". 
@@ -325,7 +323,6 @@ feedsResponse = social.getFeeds()
 
 ### Update Feed
 
-Update an RSS feed for a given ID. Returns a promise that resolves to an object containing the feed ID. See the [update feed endpoint](https://www.ayrshare.com/docs/apis/feeds/update-feed) for more details.
 Update an RSS feed for a given ID. Returns a promise that resolves to an object containing the feed ID. See the [update feed endpoint](https://www.ayrshare.com/docs/apis/feeds/update-feed) for more details.
 
 ``` python
@@ -374,7 +371,6 @@ deleteCommentResponse = social.deleteComments({
 ### Reply Comment
 
 Reply to a comment. Available for Facebook, Instagram, LinkedIn, TikTok, X/Twitter, and YouTube. See the [reply comment endpoint](https://www.ayrshare.com/docs/apis/comments/reply-to-comment) for more details.
-Reply to a comment. Available for Facebook, Instagram, LinkedIn, TikTok, X/Twitter, and YouTube. See the [reply comment endpoint](https://www.ayrshare.com/docs/apis/comments/reply-to-comment) for more details.
 
 ``` python
 replyCommentResponse = social.replyComment({
@@ -386,7 +382,7 @@ replyCommentResponse = social.replyComment({
 
 ## Business Functions for Multiple Users - Business or Enterprise Plan Required
 
-The [Business Plan](https://www.ayrshare.com/business-plan-for-multiple-users/) allows you to create, manage, and post on behalf of client profiles via the API or Dashboard GUI. You can [integrate](https://www.ayrshare.com/docs/multiple-users/business-plan-overview) Ayrshare into your platform, product, or agency and give your clients social media capabilites. Please [contact us](mailto:contact@ayrshare.com) with any questions.
+The [Business Plan](https://www.ayrshare.com/business-plan-for-multiple-users/) allows you to create, manage, and post on behalf of client profiles via the API or Dashboard GUI. You can [integrate](https://www.ayrshare.com/docs/multiple-users/business-plan-overview) Ayrshare into your platform, product, or agency and give your clients social media capabilities. Please [contact us](mailto:contact@ayrshare.com) with any questions.
 
 A User Profile PROFILE_KEY can be set with the `setProfileKey` method.
 
@@ -413,7 +409,6 @@ createProfileResponse = social.createProfile({
 ### Delete Profile
 
 Delete a profile owned by the primary account. See the [delete profile endpoint](https://www.ayrshare.com/docs/apis/profiles/delete-profile) for more details.
-Delete a profile owned by the primary account. See the [delete profile endpoint](https://www.ayrshare.com/docs/apis/profiles/delete-profile) for more details.
 
 ``` python
 deleteProfileResponse = social.deleteProfile({
@@ -424,7 +419,6 @@ deleteProfileResponse = social.deleteProfile({
 
 ### Generate a JWT URL
 
-Generate a JWT Token and URL used for authorizing a user's access to the Social Account linking page. See the [generate JWT endpoint](https://www.ayrshare.com/docs/apis/profiles/generate-jwt) for more details.
 Generate a JWT Token and URL used for authorizing a user's access to the Social Account linking page. See the [generate JWT endpoint](https://www.ayrshare.com/docs/apis/profiles/generate-jwt) for more details.
 
 ``` python
@@ -437,7 +431,6 @@ generateJWTResponse = social.generateJWT({
 
 ### Update Profile
 
-Update a profile owned by the primary account. See the [update profile endpoint](https://www.ayrshare.com/docs/apis/profiles/update-profile) for more details.
 Update a profile owned by the primary account. See the [update profile endpoint](https://www.ayrshare.com/docs/apis/profiles/update-profile) for more details.
 
 ``` python
@@ -453,7 +446,6 @@ updateProfileResponse = social.updateProfile({
 ### Get Profiles
 
 Get all the profiles associated with the primary account. See the [get profile endpoint](https://www.ayrshare.com/docs/apis/profiles/get-profiles) for more details.
-Get all the profiles associated with the primary account. See the [get profile endpoint](https://www.ayrshare.com/docs/apis/profiles/get-profiles) for more details.
 
 ``` python
 getProfileResponse = social.getProfiles()
@@ -461,7 +453,6 @@ getProfileResponse = social.getProfiles()
 
 ### Unlink Social Network
 
-Unlink a social account for a given user profile owned by the primary account. See the [unlink social network endpoint](https://www.ayrshare.com/docs/apis/profiles/unlink-social-network) for more details.
 Unlink a social account for a given user profile owned by the primary account. See the [unlink social network endpoint](https://www.ayrshare.com/docs/apis/profiles/unlink-social-network) for more details.
 
 ``` python
@@ -498,7 +489,6 @@ autoHashtagsResponse = social.autoHashtags({
 ### Recommend Hashtags
 
 Get suggestions for hashtags based on a keyword. See the [recommend hashtags endpoint](https://www.ayrshare.com/docs/apis/hashtags/recommend-hashtags) for more details.
-Get suggestions for hashtags based on a keyword. See the [recommend hashtags endpoint](https://www.ayrshare.com/docs/apis/hashtags/recommend-hashtags) for more details.
 
 ``` python
 recommendHashtagsResponse = social.recommendHashtags({
@@ -508,7 +498,6 @@ recommendHashtagsResponse = social.recommendHashtags({
 
 ### Check Banned Hashtags
 
-Check if a hashtag is banned on Instagram or other social networks. See the [check banned hashtags endpoint](https://www.ayrshare.com/docs/apis/hashtags/check-hashtags) for more details.
 Check if a hashtag is banned on Instagram or other social networks. See the [check banned hashtags endpoint](https://www.ayrshare.com/docs/apis/hashtags/check-hashtags) for more details.
 
 ``` python
@@ -520,7 +509,6 @@ checkBannedHashtagsResponse = social.checkBannedHashtags({
 ### Get All Reviews
 
 Retrieve all the reviews for the specified platform. See the [get all reviews endpoint](https://www.ayrshare.com/docs/apis/reviews/get-reviews) for more details.
-Retrieve all the reviews for the specified platform. See the [get all reviews endpoint](https://www.ayrshare.com/docs/apis/reviews/get-reviews) for more details.
 
 ``` python
 allReviewsResponse = social.reviews({
@@ -530,7 +518,6 @@ allReviewsResponse = social.reviews({
 
 ### Get Single Review
 
-Retrieve a single review. See the [get single review endpoint](https://www.ayrshare.com/docs/apis/reviews/get-one-review) for more details.
 Retrieve a single review. See the [get single review endpoint](https://www.ayrshare.com/docs/apis/reviews/get-one-review) for more details.
 
 ``` python
@@ -542,7 +529,6 @@ singleReviewResponse = social.review({
 
 ### Reply to Review
 
-Reply to a review. See the [reply to review endpoint](https://www.ayrshare.com/docs/apis/reviews/reply-review) for more details.
 Reply to a review. See the [reply to review endpoint](https://www.ayrshare.com/docs/apis/reviews/reply-review) for more details.
 
 ``` python
@@ -569,7 +555,6 @@ deleteReplyReviewResponse = social.deleteReplyReview({
 ### Generate Post
 
 Generate a new social post using ChatGPT. Token limits applicable. See the [generate post endpoint](https://www.ayrshare.com/docs/apis/generate/post-text) for more details.
-Generate a new social post using ChatGPT. Token limits applicable. See the [generate post endpoint](https://www.ayrshare.com/docs/apis/generate/post-text) for more details.
 
 ``` python
 generatePostResponse = social.generatePost({
@@ -582,7 +567,6 @@ generatePostResponse = social.generatePost({
 
 ### Generate Rewrite
 
-Generate variations of a social media post using ChatGPT. Token limits applicable. See the [generate rewrite endpoint](https://www.ayrshare.com/docs/apis/generate/rewrite-post) for more details.
 Generate variations of a social media post using ChatGPT. Token limits applicable. See the [generate rewrite endpoint](https://www.ayrshare.com/docs/apis/generate/rewrite-post) for more details.
 
 ``` python
@@ -598,7 +582,6 @@ generateRewriteResponse = social.generateRewrite({
 ### Generate Transcription
 
 Provide a transcription of a video file. See the [generate transcription endpoint](https://www.ayrshare.com/docs/apis/generate/transcribe-video) for more details.
-Provide a transcription of a video file. See the [generate transcription endpoint](https://www.ayrshare.com/docs/apis/generate/transcribe-video) for more details.
 
 ``` python
 generateTranscriptionResponse = social.generateTranscription({
@@ -608,7 +591,6 @@ generateTranscriptionResponse = social.generateTranscription({
 
 ### Generate Translation
 
-Translate text for a post to over 100 different languages. See the [generate translation endpoint](https://www.ayrshare.com/docs/apis/generate/translate-post) for more details.
 Translate text for a post to over 100 different languages. See the [generate translation endpoint](https://www.ayrshare.com/docs/apis/generate/translate-post) for more details.
 
 ``` python
@@ -630,7 +612,7 @@ generateSentiment= social.generateSentiment({
 
 ### Generate Alt Text
 
-Create AI-generated alt text for your images.  See the [generate alt text endpoint](https://www.ayrshare.com/docs/apis/generate/sentiment) for more details.
+Create AI-generated alt text for your images. See the [Generate Alt Text](https://www.ayrshare.com/docs/apis/generate/overview#generate-alt-text) section in the Generate API overview.
 
 ``` python
 generateAltTextResponse = social.generateAltText({
@@ -659,7 +641,6 @@ shortenLinkResponse = social.shortLink({
 ### Analytics for Shortened Links
 
 Return analytics for all shortened links or a single link for a given link ID. See the [analytics link endpoint](https://www.ayrshare.com/docs/apis/links/link-analytics) for more details.
-Return analytics for all shortened links or a single link for a given link ID. See the [analytics link endpoint](https://www.ayrshare.com/docs/apis/links/link-analytics) for more details.
 
 ``` python
 analyticsLinkResponse = social.shortLinkAnalytics({
@@ -673,7 +654,6 @@ analyticsLinkResponse = social.shortLinkAnalytics({
 
 ### Additional Calls
 
-- [Webhooks endpoints](https://www.ayrshare.com/docs/apis/webhooks/overview)
 - [Webhooks endpoints](https://www.ayrshare.com/docs/apis/webhooks/overview)
 - unregisterWebhook
 - listWebhook
@@ -690,11 +670,9 @@ We have other package and integrations such as [Node NPM](https://www.ayrshare.c
 Additional examples, responses, etc. can be found at:
 
 [RESTful API Endpoint Docs](https://www.ayrshare.com/docs/apis/overview)
-[RESTful API Endpoint Docs](https://www.ayrshare.com/docs/apis/overview)
 
 [GitHub](https://github.com/ayrshare/social-post-api-python)
 
-See our [changelog](https://www.ayrshare.com/docs/whatsnew/latest) for the latest and greatest.
 See our [changelog](https://www.ayrshare.com/docs/whatsnew/latest) for the latest and greatest.
 
 Please [contact us](mailto:support@ayrshare.com) with your questions, or just to give us shout-out 📢!

--- a/ayrshare/ayrshare.py
+++ b/ayrshare/ayrshare.py
@@ -78,6 +78,23 @@ class SocialPost:
             self.headers['Profile-Key'] = PROFILE_KEY
         return self
 
+    def set_twitter_byo(self, api_key, api_secret):
+        """Attach X/Twitter Bring-Your-Own-Keys consumer credentials to every
+        subsequent request.
+
+        Required for posting to X after the March 31, 2026 enforcement date.
+        See https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys.
+        """
+        self.headers['X-Twitter-OAuth1-Api-Key'] = api_key
+        self.headers['X-Twitter-OAuth1-Api-Secret'] = api_secret
+        return self
+
+    def clear_twitter_byo(self):
+        """Remove any previously-set X/Twitter BYO headers."""
+        self.headers.pop('X-Twitter-OAuth1-Api-Key', None)
+        self.headers.pop('X-Twitter-OAuth1-Api-Secret', None)
+        return self
+
     def post(self, data, headers=None):
         return doPost("post", data, self.headers)
 

--- a/ayrshare/ayrshare.py
+++ b/ayrshare/ayrshare.py
@@ -79,11 +79,10 @@ class SocialPost:
         return self
 
     def set_twitter_byo(self, api_key, api_secret):
-        """Attach X/Twitter Bring-Your-Own-Keys consumer credentials to every
-        subsequent request.
+        """Attach X/Twitter BYO (BYOK) consumer credentials to every subsequent request.
 
-        Required for posting to X after the March 31, 2026 enforcement date.
-        See https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys.
+        Required for all X/Twitter operations via Ayrshare (enforced as of
+        March 31, 2026). See https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys.
         """
         self.headers['X-Twitter-OAuth1-Api-Key'] = api_key
         self.headers['X-Twitter-OAuth1-Api-Secret'] = api_secret

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 HERE = pathlib.Path(__file__).parent
 
-VERSION = '1.2.5'
+VERSION = '1.3.0'
 PACKAGE_NAME = 'social-post-api'
 AUTHOR = 'Ayrshare'
 AUTHOR_EMAIL = 'support@ayrshare.com'

--- a/test.py
+++ b/test.py
@@ -1,15 +1,40 @@
 import json, pprint
 from ayrshare import SocialPost
 
-# Add your API Key in a file names API-KEY.json { 'key': 'API KEY'}
-print("Loading API Key...")
+# API-KEY.json example:
+# {
+#   "key": "your-ayrshare-api-key",
+#   "profile_key": "optional — Business Plan profile key; omit if unused",
+#   "twitter_consumer_key": "optional — X Developer App API Key (BYO)",
+#   "twitter_consumer_secret": "optional — X Developer App API Secret Key (BYO)"
+# }
+#
+# X/Twitter posting requires BYO consumer credentials on the request (set_twitter_byo).
+# See https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys
+
+print("Loading API-KEY.json...")
 with open('./API-KEY.json') as f:
-    API_KEY = json.load(f)
+    cfg = json.load(f)
 
-print("Initializing SocialPost...")
+ayr_key = cfg["key"]
+social = SocialPost(ayr_key)
 
-social = SocialPost(API_KEY["key"])
-social.setProfileKey('PROFILE_KEY')
+profile_key = cfg.get("profile_key")
+if profile_key:
+    social.setProfileKey(profile_key)
+
+ck = (cfg.get("twitter_consumer_key") or "").strip()
+cs = (cfg.get("twitter_consumer_secret") or "").strip()
+if ck and cs:
+    social.set_twitter_byo(ck, cs)
+    print("Twitter/X BYO headers enabled (consumer key + secret).")
+else:
+    print(
+        "WARNING: twitter_consumer_key / twitter_consumer_secret missing — "
+        "X/Twitter requests will fail (BYO is enforced). "
+        "Add both fields to API-KEY.json or use platforms without twitter."
+    )
+
 pp = pprint.PrettyPrinter(indent=4)
 
 print("Running Tests...")
@@ -18,8 +43,16 @@ print("Running Tests...")
 postResult = social.post({'randomPost': True, 'platforms': ['twitter']})
 print(postResult)
 
+# /post returns the Ayrshare post ID at the top level as `id`.
+# Per-platform IDs (e.g. the Twitter status ID) live under `postIds`,
+# but getPost/delete/analytics all take the Ayrshare-level `id`.
+# See https://www.ayrshare.com/docs/apis/overview#social-post-id
+ayr_post_id = postResult.get('id')
+if not ayr_post_id:
+    raise SystemExit(f"Post failed; no Ayrshare id in response: {postResult}")
+
 # Get Post
-getResult = social.getPost({ 'id': postResult['posts'][0]['id']})
+getResult = social.getPost({'id': ayr_post_id})
 print(getResult)
 
 # Retry Post
@@ -31,7 +64,7 @@ print(getResult)
 #print(updateResult)
 
 # Delete the Post
-deleteResult = social.delete({'id': postResult['posts'][0]['id']})
+deleteResult = social.delete({'id': ayr_post_id})
 print(deleteResult)
 
 # Get History

--- a/test.py
+++ b/test.py
@@ -13,10 +13,21 @@ from ayrshare import SocialPost
 # See https://docs.ayrshare.com/dashboard/connect-social-accounts/x-twitter-byo-keys
 
 print("Loading API-KEY.json...")
-with open('./API-KEY.json') as f:
-    cfg = json.load(f)
+try:
+    with open('./API-KEY.json', encoding='utf-8') as f:
+        cfg = json.load(f)
+    ayr_key = cfg['key']
+except FileNotFoundError:
+    raise SystemExit(
+        "API-KEY.json not found in the current directory. "
+        "Create it with at least {\"key\": \"<your-ayrshare-api-key>\"} — "
+        "see the comment at the top of test.py for the full schema."
+    )
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"API-KEY.json is invalid JSON: {exc}")
+except KeyError:
+    raise SystemExit("API-KEY.json is missing required field: 'key'.")
 
-ayr_key = cfg["key"]
 social = SocialPost(ayr_key)
 
 profile_key = cfg.get("profile_key")

--- a/tests/test_byo.py
+++ b/tests/test_byo.py
@@ -1,0 +1,55 @@
+import unittest
+
+from ayrshare import SocialPost
+
+
+KEY_HEADER = 'X-Twitter-OAuth1-Api-Key'
+SECRET_HEADER = 'X-Twitter-OAuth1-Api-Secret'
+
+
+class TwitterBYOHeadersTest(unittest.TestCase):
+    def test_headers_absent_when_byo_never_set(self):
+        social = SocialPost('API_KEY')
+        self.assertNotIn(KEY_HEADER, social.headers)
+        self.assertNotIn(SECRET_HEADER, social.headers)
+
+    def test_set_twitter_byo_injects_both_headers(self):
+        social = SocialPost('API_KEY')
+        social.set_twitter_byo('ck_123', 'cs_456')
+        self.assertEqual(social.headers[KEY_HEADER], 'ck_123')
+        self.assertEqual(social.headers[SECRET_HEADER], 'cs_456')
+
+    def test_clear_twitter_byo_removes_both_headers(self):
+        social = SocialPost('API_KEY')
+        social.set_twitter_byo('ck_123', 'cs_456')
+        social.clear_twitter_byo()
+        self.assertNotIn(KEY_HEADER, social.headers)
+        self.assertNotIn(SECRET_HEADER, social.headers)
+
+    def test_clear_twitter_byo_is_noop_when_nothing_set(self):
+        social = SocialPost('API_KEY')
+        # Should not raise even when nothing is set.
+        social.clear_twitter_byo()
+        self.assertNotIn(KEY_HEADER, social.headers)
+
+    def test_setters_are_chainable(self):
+        social = SocialPost('API_KEY')
+        self.assertIs(social.set_twitter_byo('a', 'b'), social)
+        self.assertIs(social.clear_twitter_byo(), social)
+
+    def test_byo_coexists_with_profile_key(self):
+        social = SocialPost('API_KEY')
+        social.setProfileKey('PK').set_twitter_byo('ck', 'cs')
+        self.assertEqual(social.headers['Profile-Key'], 'PK')
+        self.assertEqual(social.headers[KEY_HEADER], 'ck')
+        self.assertEqual(social.headers[SECRET_HEADER], 'cs')
+
+    def test_instances_have_independent_byo_state(self):
+        a = SocialPost('A').set_twitter_byo('a_k', 'a_s')
+        b = SocialPost('B')
+        self.assertNotIn(KEY_HEADER, b.headers)
+        self.assertEqual(a.headers[KEY_HEADER], 'a_k')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a chainable `set_twitter_byo(api_key, api_secret)` method (plus `clear_twitter_byo()`) on the SDK so customers can inject their own X/Twitter consumer credentials without dropping down to raw `requests` calls. Required for posting to X after the **March 31, 2026** BYO enforcement date.

```python
from ayrshare import SocialPost

social = SocialPost(API_KEY)
social.set_twitter_byo(MY_X_API_KEY, MY_X_API_SECRET)

social.post({"post": "Hello", "platforms": ["twitter"]})
# → request includes X-Twitter-OAuth1-Api-Key + X-Twitter-OAuth1-Api-Secret
```

Tracks [AE-313](https://ayrshareteam.atlassian.net/browse/AE-313). Sibling PRs: Node SDK (AE-312) and Mintlify package guides.

## Why

The Ayrshare REST API already accepts `X-Twitter-OAuth1-Api-Key` / `X-Twitter-OAuth1-Api-Secret` headers, but `self.headers` had no extension point for them. SDK users were going to be hard-blocked on every X post the moment server-side enforcement flips on. This adds the minimal additive API to keep them unblocked.

## Changes

- `ayrshare/ayrshare.py`
  - New `set_twitter_byo(api_key, api_secret)` — adds both headers to `self.headers`, returns `self` (chainable, mirrors `setProfileKey`)
  - New `clear_twitter_byo()` — pops both headers (no-op if absent), returns `self`
  - Every existing method already builds requests off `self.headers`, so all routes pick up BYO automatically when set
- `setup.py` — bump 1.2.5 → 1.3.0
- `CHANGELOG.md` — 1.3.0 entry
- `README.md` — new "X/Twitter Bring-Your-Own-Keys (BYO)" section with happy-path + multi-tenant rotation example
- `tests/test_byo.py` — 7 unit tests via stdlib `unittest`: headers absent / set / cleared / no-op clear / chainable / coexists with profileKey / per-instance isolation

## Spec divergence from the ticket

The original ticket mentioned a 4-arg setter (`api_key, api_secret, access_token, access_token_secret`) emitting 4 headers. We narrowed to **2 args / 2 headers** to match `snippets/x-byo-notice.mdx` and how the REST API actually consumes BYO — Ayrshare resolves per-account access tokens server-side after the user links X via OAuth. The spec doc captures the rationale.

## Non-goals (intentional)

- No client-side credential validation (server-side `validateXCredentialPairs` / `checkByokGate` already enforces).
- No persistence of BYO credentials; lives in the SDK instance only.
- No OAuth 2.0 client-id/secret support yet.

## Test plan

- [x] `python -m unittest tests.test_byo` — 7/7 pass
- [ ] Manual smoke: `python -m build`, install wheel into a fresh venv, real `social.post({platforms: ["twitter"]})` against staging with valid BYO consumer keys → expect 200
- [ ] Manual smoke: same flow without `set_twitter_byo` → expect server 419 surfaced cleanly
- [ ] After merge: `python -m build && twine upload dist/*` (1.3.0 to PyPI)

Created with [p0 by Purple](https://bepurple.ai) in Spec mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * X/Twitter Bring-Your-Own-Keys (BYO) support so users can supply their own X Developer App credentials; BYO headers are included on X-bound requests and can be toggled per client.

* **Documentation**
  * README and docs updated with BYO setup, rotation guidance for multi-tenant setups, usage examples, and various wording/link fixes.

* **Tests**
  * New tests verifying BYO header behavior, chaining, and instance isolation.

* **Changelog**
  * Release bumped to v1.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->